### PR TITLE
Use install-swift-tool for installing xcbeautify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           xcodebuild test \
             -project TestAppDelegateExample.xcodeproj \
             -scheme TestAppDelegateExample \
-            -destination 'platform=iOS Simulator,name=iPhone 12 Pro' -sdk iphonesimulator # | xcbeautify
+            -destination 'platform=iOS Simulator,name=iPhone 12 Pro' -sdk iphonesimulator | xcbeautify
 
   swiftui-only-tests:
     runs-on: macos-11.0
@@ -35,7 +35,7 @@ jobs:
           xcodebuild test \
             -project TestAppExample.xcodeproj \
             -scheme TestAppExample \
-            -destination 'platform=iOS Simulator,name=iPhone 12 Pro' -sdk iphonesimulator # | xcbeautify
+            -destination 'platform=iOS Simulator,name=iPhone 12 Pro' -sdk iphonesimulator | xcbeautify
 
 
   swiftui-wit-uikit-only-tests:
@@ -53,4 +53,4 @@ jobs:
           xcodebuild test \
             -project MixedSwiftUIUIKitExample.xcodeproj \
             -scheme MixedSwiftUIUIKitExample \
-            -destination 'platform=iOS Simulator,name=iPhone 12 Pro' -sdk iphonesimulator # | xcbeautify
+            -destination 'platform=iOS Simulator,name=iPhone 12 Pro' -sdk iphonesimulator | xcbeautify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,21 +7,11 @@ jobs:
     runs-on: macos-11.0
     steps:
       - uses: actions/checkout@v2
-      # I wanted to use xcbeautify to make the logs cleaner, but it fails to
-      # install (1) because macos-11, at the time of writing, has Xcode 11 as
-      # the default and the tool requires 12.1 (2)
-      #
-      # As you can see above, I set the DEVELOPER_DIR environment variable, but
-      # it doesn't seem to work for this step (3).
-      #
-      # References:
-      # 1. https://github.com/actions/virtual-environments/blob/a31ef3fcfe1eebb2fc8e557b76d85315d5651991/images/macos/macos-11.0-Readme.md
-      # 2. https://github.com/mokacoding/TestAppDelegateExample/runs/1383211558?check_suite_focus=true#step:3:18
-      # 3. https://github.com/mokacoding/TestAppDelegateExample/runs/1383279298?check_suite_focus=true#step:3:20
-      #
-      # - run: |
-      #     brew tap thii/xcbeautify https://github.com/thii/xcbeautify.git
-      #     brew install xcbeautify
+      - name: Install xcbeautify
+        uses: Cyberbeni/install-swift-tool@v2
+        with:
+          url: https://github.com/thii/xcbeautify
+          version: '*'
       - name: UIKit Example Tests
         run: |
           cd UIKit-Example
@@ -34,9 +24,11 @@ jobs:
     runs-on: macos-11.0
     steps:
       - uses: actions/checkout@v2
-      # - run: |
-      #     brew tap thii/xcbeautify https://github.com/thii/xcbeautify.git
-      #     brew install xcbeautify
+      - name: Install xcbeautify
+        uses: Cyberbeni/install-swift-tool@v2
+        with:
+          url: https://github.com/thii/xcbeautify
+          version: '*'
       - name: SwiftUI Example Tests
         run: |
           cd SwiftUI-Example
@@ -50,9 +42,11 @@ jobs:
     runs-on: macos-11.0
     steps:
       - uses: actions/checkout@v2
-      # - run: |
-      #     brew tap thii/xcbeautify https://github.com/thii/xcbeautify.git
-      #     brew install xcbeautify
+      - name: Install xcbeautify
+        uses: Cyberbeni/install-swift-tool@v2
+        with:
+          url: https://github.com/thii/xcbeautify
+          version: '*'
       - name: Mixed SwiftUI and UIKit Example Tests
         run: |
           cd Mixed-SwiftUI-UIKit-Example


### PR DESCRIPTION
This builds xcbeautify from source and adds it to your path. It also caches the build, so next time it will be faster. Caches get cleared after 1 week of not using them. [If you cache something on a branch, it won't be available on the default branch but once there is a cache on the default branch, the other branches can use it too](https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache).

Workflow run can be found here (waiting for start at this moment): https://github.com/Cyberbeni/TestAppDelegateExample/actions/runs/366761715